### PR TITLE
adding username to send emails, if pid is received

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ Emailer.send = function(data) {
 
         async.waterfall([
             function(next) {
-                if (headers.hasOwnProperty('Reply-To')) {
+                if (data.fromUid) {
+                    next(null, data.fromUid);
+                } else if (data.pid) {
                     Posts.getPostField(data.pid, 'uid', next);
                 } else {
                     next(null, false);
@@ -67,7 +69,7 @@ Emailer.send = function(data) {
             function(uid, next) {
                 if (uid === false) { return next(null, {}); }
 
-                User.getUserFields(uid, ['email', 'username'], function(err, userData) {
+                User.getUserFields(parseInt(uid, 10), ['email', 'username'], function(err, userData) {
                     next(null, userData);
                 });
             },

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ Emailer.send = function(data) {
                         to: [{email: data.to, name: data.toName}],
                         subject: data.subject,
                         from_email: userData.email || data.from,
-                        from_name: userData.username ? userData.username + ' (' + (Meta.config.title || 'NodeBB') + ')' : undefined,
+                        from_name: userData.username ? userData.username : undefined,
                         html: data.html,
                         text: data.plaintext,
                         auto_text: !!!data.plaintext,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-emailer-mandrill",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An emailer plugin for NodeBB using Mandrill as a third party service",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "node-mandrill": "~1.0.1"
   },
   "nbbpm": {
-    "compatibility": "^0.6.0"
+    "compatibility": "^0.6.0 || ^0.7.0 || ^0.8.0"
   }
 }


### PR DESCRIPTION
This allows the proper username to be shown in the "From" field in an email, if the email pertains to a specific pid:

![selection_024](https://cloud.githubusercontent.com/assets/923011/6629562/ac3504f8-c8e5-11e4-8461-4e86b97951bf.png)
