### PR TITLE
Fix recommended Mandrill webhook URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ Emailer.init = function(data, callback) {
 
     var render = function(req, res) {
         res.render('admin/plugins/emailer-mandrill', {
-            url: nconf.get('url')
+            url: nconf.get('url'),
+            base_url: nconf.get('base_url')
         });
     };
 

--- a/templates/admin/plugins/emailer-mandrill.tpl
+++ b/templates/admin/plugins/emailer-mandrill.tpl
@@ -55,7 +55,7 @@
 					<li>
 					    Establish the following routes (<a href="https://mandrillapp.com/inbound/routes">configurable in this page</a>):
 					    <ul>
-					    	<li><code>reply-*</code>, post to URL: <code>{url}/emailer-mandrill/reply</code></li>
+					    	<li><code>reply-*</code>, post to URL: <code>{base_url}/emailer-mandrill/reply</code></li>
 					    </ul>
 					</li>
 				</ol>


### PR DESCRIPTION
This PR restores the email reply functionality via the Mandrill plugin by exposing two public routes which can be used for Mandrill webhooks.

It also includes [node-email-reply-parser](https://www.npmjs.com/package/node-email-reply-parser) to have GitHub-like email content filtering.