### PR TITLE
Update 1.4.x and 1.5.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "node-mandrill": "~1.0.1"
   },
   "nbbpm": {
-    "compatibility": "^0.9.0"
+    "compatibility": "^0.9.0 || ~1.4.0 || ~1.5.0"
   }
 }


### PR DESCRIPTION
I have successfully been using this plugin on `1.4.x` and `1.5.x` so I guess it is still compatible with these versions.