### PR TITLE
Fix `from` email for Mandrill

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ Emailer.send = function(data, callback) {
                     message: {
                         to: [{email: data.to, name: data.toName}],
                         subject: data.subject,
-                        from_email: userData.email || data.from,
+                        from_email: data.from,
                         from_name: data.from_name || userData.username || undefined,
                         html: data.html,
                         text: data.plaintext,


### PR DESCRIPTION
Mandrill does not allow sending mails with email addresses from other domains. Sending with the user's email in the `from` field should therefore be avoided.