### PR TITLE
GitHub-like email reply filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ Emailer.processEvent = function(eventObj, callback) {
         uid: eventObj.uid,
         toPid: eventObj.pid,
         tid: eventObj.tid,
-        content: eventObj.msg.text,
+        content: require('node-email-reply-parser')(eventObj.msg.text, true),
         handle: (eventObj.uid === 0 && eventObj.hasOwnProperty('handle') ? eventObj.handle : undefined)
     }, callback);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/akhoury/nodebb-plugin-emailer-mandrill",
   "dependencies": {
     "path": "~0.4.9",
+    "node-email-reply-parser": "^0.1.0",
     "node-mandrill": "~1.0.1"
   },
   "nbbpm": {


### PR DESCRIPTION
Have some GitHub-like email reply filtering which removes e.g. signatures and reply fragments. More info: https://github.com/turt2live/node-email-reply-parser